### PR TITLE
Do not deep clone the inputs

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -1,4 +1,4 @@
-const { isEmpty, isObject, isArray, isString, reduce, map, isNull, isUndefined, isNaN, cloneDeep } = require('lodash')
+const { isEmpty, isObject, isArray, isString, reduce, map, isNull, isUndefined, isNaN, clone } = require('lodash')
 const { doNotAllowMissingProperties, allowMissingProperties } = require('@little-universe/do-not-allow-missing-properties')
 
 const HaltExecution = {}
@@ -17,7 +17,9 @@ const Command = class {
 
   constructor (inputs = {}) {
     this._rawInputs = inputs
-    this.inputs = doNotAllowMissingProperties(cloneDeep(inputs))
+    // maybe add a mutable property to the schema that defaults to false
+    // and cloneDeep objects that are not mutable
+    this.inputs = doNotAllowMissingProperties(clone(inputs))
     this._started = false
     this._completed = false
     this._outcome = Outcome.create()


### PR DESCRIPTION
This is a blocker for the current implementation of RYR. The deepClone makes it so that the outer ryrRequestLogger doesn't receive any changes made to the cloned one passed in the inputs.

There might be better ways to solve this but for now I need to merge this to unblock RYR.