### PR TITLE
Allow empty Command schema + unit test

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -26,7 +26,15 @@ const Command = class {
   }
 
   static create (rawInputs) {
-    return doNotAllowMissingProperties(new this(rawInputs))
+    const command = doNotAllowMissingProperties(new this(rawInputs))
+    this._validateCreation(command)
+    return command
+  }
+
+  static _validateCreation (newlyCreatedCommandInstance) {
+    if (isNull(newlyCreatedCommandInstance.schema) || isUndefined(newlyCreatedCommandInstance.schema)) {
+      newlyCreatedCommandInstance.constructor.schema = {}
+    }
   }
 
   static run (rawInputs) {

--- a/src/command.test.js
+++ b/src/command.test.js
@@ -7,24 +7,36 @@ const { Command } = require('./command')
 describe('Command', () => {
   beforeEach(() => { clearAllMocks() })
 
-  describe('empty command', () => {
-    class TestCommand extends Command {
-      // TODO: This will be static later, will be addressed in other PR.
-      schema =
-        {
+  describe('with empty schema', () => {
+    describe('explicit version', () => {
+      describe('static run', () => {
+        class TestCommand extends Command {
+          schema = {}
 
+          execute () {
+            return 'We made it!'
+          }
         }
+        it.only('executes successfully', async () => {
+          const outcome = await TestCommand.run()
+          expect(outcome.success).toBe(true)
+          expect(outcome.result).toBe('We made it!')
+        })
+      })
+    })
 
-      execute () {
-        return 'Result!'
-      }
-    }
-
-    describe('run', () => {
-      it('Is successful', async () => {
-        const outcome = await TestCommand.run()
-        expect(outcome.success).toBe(true)
-        expect(outcome.result).toBe('Result!')
+    describe('implicit version', () => {
+      describe('static run', () => {
+        class TestCommand extends Command {
+          execute () {
+            return 'We made it!'
+          }
+        }
+        it.only('executes successfully', async () => {
+          const outcome = await TestCommand.run()
+          expect(outcome.success).toBe(true)
+          expect(outcome.result).toBe('We made it!')
+        })
       })
     })
   })


### PR DESCRIPTION
References this ticket:

https://linear.app/grid-alternatives/issue/GRI-2565/allow-empty-command-schema