### PR TITLE
Fix bug making date inputs look blank

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -1,4 +1,4 @@
-const { isEmpty, isObject, isArray, isString, reduce, map, isNull, isUndefined, isNaN, clone } = require('lodash')
+const { isEmpty, isPlainObject, isArray, isString, reduce, map, isNull, isUndefined, isNaN, clone } = require('lodash')
 const { doNotAllowMissingProperties, allowMissingProperties } = require('@little-universe/do-not-allow-missing-properties')
 
 const HaltExecution = {}
@@ -340,7 +340,7 @@ const Outcome = class {
 
 const isBlankString = (value) => isString(value) && !!value.match(/^\s*$/) // no \A or \z in JavaScript??
 const isEmptyArray = (value) => isArray(value) && isEmpty(value)
-const isEmptyObject = (value) => isObject(value) && isEmpty(value)
+const isEmptyObject = (value) => isPlainObject(value) && isEmpty(value)
 
 const isBlank = (value) => {
   return isNull(value) || isUndefined(value) || isBlankString(value) || isEmptyArray(value) || isEmptyObject(value) || isNaN(value)

--- a/src/command.test.js
+++ b/src/command.test.js
@@ -230,4 +230,27 @@ describe('Command', () => {
       })
     })
   })
+
+  describe('with required Date inputs', () => {
+    class TestCommand extends Command {
+      static schema = {
+        input1: { type: 'date', required: true }
+      }
+
+      execute () {
+        return this.inputs.input1
+      }
+    }
+
+    describe('run', () => {
+      it('Is successful', async () => {
+        const now = new Date()
+
+        const outcome = await TestCommand.run({ input1: now })
+
+        expect(outcome.success).toBe(true)
+        expect(outcome.result).toBe(now)
+      })
+    })
+  })
 })


### PR DESCRIPTION
This surprising lodash behavior results in required date inputs always seeming to be blank, incorrectly:

```
miles@sunfish:~/gitlocal/little-universe/command$ node
Welcome to Node.js v14.18.0.
Type ".help" for more information.
> require('lodash').isEmpty(new Date())
true
> 
```

This fixes that